### PR TITLE
Fix SQLITE_BUSY by using modernc-compatible pragma DSN

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"log"
 	"log/slog"
 	"net/http"
@@ -20,7 +19,6 @@ import (
 	"github.com/dir01/mediary/storage"
 	"github.com/dir01/mediary/uploader"
 	"github.com/joho/godotenv"
-	_ "modernc.org/sqlite"
 )
 
 func main() {
@@ -83,7 +81,7 @@ func main() {
 	// dwn is a composite downloader: it can download anything, as long as one of its minions knows how to
 	dwn := downloader.NewCompositeDownloader([]service.Downloader{torrentDownloader, ytdlDownloader})
 
-	db, err := sql.Open("sqlite", "file:"+sqliteDBPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	db, err := storage.OpenSQLiteDB(sqliteDBPath)
 	if err != nil {
 		log.Fatalf("error opening sqlite database: %v", err)
 	}

--- a/service/jobs_queue/jobs_queue_test.go
+++ b/service/jobs_queue/jobs_queue_test.go
@@ -99,7 +99,7 @@ func TestSQLJobsQueue(t *testing.T) {
 
 func openTestDB(t *testing.T) *sql.DB {
 	t.Helper()
-	db, err := sql.Open("sqlite", "file::memory:?cache=shared&_journal_mode=WAL")
+	db, err := sql.Open("sqlite", "file::memory:?cache=shared&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)")
 	if err != nil {
 		t.Fatalf("error opening in-memory sqlite db: %v", err)
 	}

--- a/storage/open.go
+++ b/storage/open.go
@@ -1,0 +1,56 @@
+package storage
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "modernc.org/sqlite"
+)
+
+// SQLiteBusyTimeoutMS is the busy_timeout (in milliseconds) applied to every
+// SQLite connection. It must be large enough to absorb contention with
+// litestream's WAL checkpointing and the jobs-queue worker's read transactions;
+// without it, concurrent writes fail immediately with SQLITE_BUSY.
+const SQLiteBusyTimeoutMS = 5000
+
+// OpenSQLiteDB opens the SQLite database at path with the pragmas mediary relies
+// on (WAL journal mode + busy_timeout) and verifies they actually took effect.
+//
+// The verification is deliberate: modernc.org/sqlite only honors the `_pragma`
+// DSN form and silently ignores the mattn-style `_journal_mode`/`_busy_timeout`
+// keys. A wrong DSN therefore leaves busy_timeout at 0 and surfaces much later
+// as intermittent "database is locked (SQLITE_BUSY)" errors under load. Failing
+// fast at open turns that into an immediate, obvious startup error and keeps
+// production and tests from silently drifting apart.
+func OpenSQLiteDB(path string) (*sql.DB, error) {
+	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(%d)&_pragma=journal_mode(WAL)", path, SQLiteBusyTimeoutMS)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("opening sqlite database: %w", err)
+	}
+	if err := verifySQLitePragmas(db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+// verifySQLitePragmas confirms the pragmas set via the DSN actually took effect.
+func verifySQLitePragmas(db *sql.DB) error {
+	var journalMode string
+	if err := db.QueryRow("PRAGMA journal_mode").Scan(&journalMode); err != nil {
+		return fmt.Errorf("reading journal_mode pragma: %w", err)
+	}
+	if journalMode != "wal" {
+		return fmt.Errorf("expected WAL journal mode, got %q (DSN pragmas not applied?)", journalMode)
+	}
+
+	var busyTimeout int
+	if err := db.QueryRow("PRAGMA busy_timeout").Scan(&busyTimeout); err != nil {
+		return fmt.Errorf("reading busy_timeout pragma: %w", err)
+	}
+	if busyTimeout != SQLiteBusyTimeoutMS {
+		return fmt.Errorf("expected busy_timeout=%d, got %d (DSN pragmas not applied?)", SQLiteBusyTimeoutMS, busyTimeout)
+	}
+	return nil
+}

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -5,7 +5,6 @@ package tests
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -27,7 +26,6 @@ import (
 	jobsqueue "github.com/dir01/mediary/service/jobs_queue"
 	"github.com/dir01/mediary/storage"
 	"github.com/dir01/mediary/uploader"
-	_ "modernc.org/sqlite"
 )
 
 var logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
@@ -71,12 +69,13 @@ func TestApplication(t *testing.T) {
 
 	dwn := downloader.NewCompositeDownloader([]service.Downloader{torrDwn, ytdlpDwn})
 
-	// Use a temp file (not in-memory) so WAL mode actually takes effect.
-	// In-memory SQLite silently ignores _journal_mode=WAL and falls back to DELETE
-	// mode, where sqlq's read transaction blocks SaveJob writes from committing.
-	// WAL mode allows concurrent readers and writers on the same file.
+	// Use a temp file (not in-memory) so WAL mode actually takes effect: in-memory
+	// SQLite can't use WAL and falls back to DELETE mode, where sqlq's read transaction
+	// blocks SaveJob writes from committing. WAL allows concurrent readers and writers.
+	// OpenSQLiteDB shares the exact DSN with production and verifies WAL + busy_timeout
+	// actually took effect, so this test can't silently drift from cmd/server/main.go.
 	dbPath := t.TempDir() + "/e2e.db"
-	db, err := sql.Open("sqlite", "file:"+dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	db, err := storage.OpenSQLiteDB(dbPath)
 	if err != nil {
 		t.Fatalf("error opening sqlite db: %v", err)
 	}


### PR DESCRIPTION
mediary opened SQLite with the mattn/go-sqlite3 DSN form (`_journal_mode=WAL&_busy_timeout=5000`), but the driver is modernc.org/sqlite, which only honors `_pragma=...` params and silently ignores those keys. busy_timeout was therefore 0, so any write that collided with litestream's WAL checkpoint or the jobs-queue worker's read transaction failed immediately with "database is locked (SQLITE_BUSY)" instead of waiting.

Introduce storage.OpenSQLiteDB, which opens with the correct `_pragma=busy_timeout(...)&_pragma=journal_mode(WAL)` DSN and verifies the pragmas actually took effect, failing fast at startup instead of surfacing as intermittent lock errors under load. main.go and the e2e test now share this helper so they can't drift apart. Fix the same DSN syntax in the jobs_queue in-memory test.