### PR TITLE
Speed up Docker image build for arm64-only target

### DIFF
--- a/.github/workflows/do_build_image.yml
+++ b/.github/workflows/do_build_image.yml
@@ -12,7 +12,8 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    # Native arm64 runner (free for public repos) avoids slow QEMU emulation.
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -20,10 +21,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-
-      # https://github.com/docker/setup-qemu-action
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
@@ -59,7 +56,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,28 @@
-FROM golang:1.26-alpine
+# syntax=docker/dockerfile:1
 
-RUN apk add --no-cache gcc musl-dev g++ ffmpeg python3
+FROM golang:1.26-alpine AS builder
 
-RUN wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O /usr/local/bin/yt-dlp && chmod +x /usr/local/bin/yt-dlp
+WORKDIR /app
+# modernc.org/sqlite is pure Go, so we build without CGO and skip the C toolchain.
+ENV CGO_ENABLED=0
 
-RUN mkdir /app
-ENV GOPATH=""
-ADD go.mod go.sum ./
-RUN go mod download
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-ADD . .
-RUN GOPATH= go build -o bin/server ./cmd/server
+COPY . .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -o /bin/server ./cmd/server
 
-CMD ["bin/server"]
+FROM alpine:3.21
+
+RUN apk add --no-cache ffmpeg python3
+
+# Pin to a specific release (e.g. .../releases/download/2025.01.01/yt-dlp) for reproducible builds.
+RUN wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O /usr/local/bin/yt-dlp \
+    && chmod +x /usr/local/bin/yt-dlp
+
+COPY --from=builder /bin/server /usr/local/bin/server
+
+CMD ["server"]


### PR DESCRIPTION
The image is only deployed to arm64, but CI built linux/amd64,linux/arm64 on an amd64 runner, so arm64 was compiled under slow QEMU emulation.

- Build on a native ubuntu-24.04-arm runner and drop the QEMU step
- Build only linux/arm64
- Multi-stage Dockerfile with CGO_ENABLED=0 (modernc.org/sqlite is pure Go), dropping the gcc/g++/musl-dev build toolchain and shrinking the runtime image to ffmpeg + python3 + yt-dlp + the static binary
- BuildKit cache mounts for the Go module and build caches