### PR TITLE
Raise flow timeouts so large uploads and job-state saves don't fail

### DIFF
--- a/service/concatenate_flow.go
+++ b/service/concatenate_flow.go
@@ -44,7 +44,7 @@ func (svc *Service) newConcatenateFlow(jobID string, job *Job) (func(ctx context
 		)
 		defer span.End()
 
-		ctx, cancel := context.WithTimeout(jobCtx, 1*time.Second)
+		ctx, cancel := context.WithTimeout(jobCtx, 10*time.Second)
 		defer cancel()
 		job, err := svc.storage.GetJob(ctx, jobID)
 		if err != nil {
@@ -57,7 +57,7 @@ func (svc *Service) newConcatenateFlow(jobID string, job *Job) (func(ctx context
 
 		updateJobStatus := func(status string) {
 			job.DisplayStatus = status
-			statusCtx, statusCancel := context.WithTimeout(jobCtx, 1*time.Second)
+			statusCtx, statusCancel := context.WithTimeout(jobCtx, 10*time.Second)
 			defer statusCancel()
 			if err = svc.storage.SaveJob(statusCtx, job); err != nil {
 				attrs := append([]any{
@@ -122,7 +122,7 @@ func (svc *Service) newConcatenateFlow(jobID string, job *Job) (func(ctx context
 			}
 
 			svc.log.Debug("starting conversion", logAttrs...)
-			concatCtx, concatCancel := context.WithTimeout(jobCtx, 30*time.Minute)
+			concatCtx, concatCancel := context.WithTimeout(jobCtx, 1*time.Hour)
 			defer concatCancel()
 
 			concatCtx, concatSpan := otel.Tracer("github.com/dir01/mediary/service").Start(concatCtx, "service.Concatenate",
@@ -170,7 +170,7 @@ func (svc *Service) newConcatenateFlow(jobID string, job *Job) (func(ctx context
 		updateJobStatus(JobStatusUploading)
 		svc.log.Debug("starting upload", logAttrs...)
 
-		uploadCtx, uploadCancel := context.WithTimeout(jobCtx, 30*time.Minute)
+		uploadCtx, uploadCancel := context.WithTimeout(jobCtx, 2*time.Hour)
 		defer uploadCancel()
 
 		err = svc.uploader.Upload(uploadCtx, resultFilepath, params.UploadURL)

--- a/service/encode_flow.go
+++ b/service/encode_flow.go
@@ -44,7 +44,7 @@ func (svc *Service) newUploadOriginalFlow(jobID string, job *Job) (func(ctx cont
 		)
 		defer span.End()
 
-		ctx, cancel := context.WithTimeout(jobCtx, 1*time.Second)
+		ctx, cancel := context.WithTimeout(jobCtx, 10*time.Second)
 		defer cancel()
 		job, err := svc.storage.GetJob(ctx, jobID)
 		if err != nil {
@@ -54,7 +54,7 @@ func (svc *Service) newUploadOriginalFlow(jobID string, job *Job) (func(ctx cont
 		}
 
 		updateJobStatus := func(status string) {
-			statusCtx, statusCancel := context.WithTimeout(jobCtx, 1*time.Second)
+			statusCtx, statusCancel := context.WithTimeout(jobCtx, 10*time.Second)
 			defer statusCancel()
 			job.DisplayStatus = status
 			if err = svc.storage.SaveJob(statusCtx, job); err != nil {
@@ -113,7 +113,7 @@ func (svc *Service) newUploadOriginalFlow(jobID string, job *Job) (func(ctx cont
 		updateJobStatus(JobStatusUploading)
 		svc.log.Debug("starting upload", logAttrs...)
 
-		uploadCtx, uploadCancel := context.WithTimeout(jobCtx, 30*time.Minute)
+		uploadCtx, uploadCancel := context.WithTimeout(jobCtx, 2*time.Hour)
 		defer uploadCancel()
 
 		err = svc.uploader.Upload(uploadCtx, downloadedFilepath, params.UploadURL)

--- a/service/jobs_queue/jobs_queue.go
+++ b/service/jobs_queue/jobs_queue.go
@@ -16,8 +16,13 @@ type SQLQ struct {
 }
 
 func NewSQLJobsQueue(db *sql.DB, logger *slog.Logger) (*SQLQ, error) {
+	// This is the deadline for the whole job and is the parent of every per-stage
+	// context in the flows (download 1h + concat 1h + upload 2h). It must exceed the
+	// sum of those stage budgets, otherwise time spent downloading/concatenating eats
+	// into the upload's budget and a large S3 PUT gets cancelled before its own
+	// per-stage timeout. 5h leaves headroom above the 4h worst-case sum.
 	q, err := sqlq.New(db, sqlq.DBTypeSQLite,
-		sqlq.WithDefaultJobTimeout(2*time.Hour),
+		sqlq.WithDefaultJobTimeout(5*time.Hour),
 	)
 	if err != nil {
 		return nil, oops.Wrapf(err, "failed to create sqlq")


### PR DESCRIPTION
Large audiobook episodes (~900MB concatenated) were exceeding the 30-minute upload context, so every S3 PUT failed with "context deadline exceeded" and the flow retried indefinitely. Raise the upload timeout to 2h and the concat timeout to 1h to fit large jobs.

Also raise the per-call job-state context (GetJob / SaveJob status updates) from 1s to 10s. With busy_timeout now at 5s, a contended SQLite write waits for the lock up to 5s, which the old 1s deadline cut short — surfacing as "failed to save job state ... context deadline exceeded". 10s leaves headroom above busy_timeout.

Applies to both the concatenate and upload-original flows.